### PR TITLE
Update lint dependencies and fix errors

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -87,6 +87,9 @@ select = ["ALL"]
 target-version = "py38"
 
 [tool.ruff.per-file-ignores]
+"{{ cookiecutter.module_slug }}/_cli.py" = [
+    "T201", # allow `print` in cli module
+]
 "test/**/*.py" = [
     "D",    # no docstrings in tests
     "S101", # asserts are expected in tests

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -32,10 +32,10 @@ doc = [
 ]
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
-    "black>=22.3.0",
+    "black ~= 23.0",
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.
-    "ruff < 0.0.255",
+    "ruff < 0.0.293",
     "mypy >= 1.0",
     "types-html5lib",
     "types-requests",

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -86,6 +86,12 @@ line-length = 100
 select = ["ALL"]
 target-version = "py38"
 
+[tool.ruff.per-file-ignores]
+"test/**/*.py" = [
+    "D",    # no docstrings in tests
+    "S101", # asserts are expected in tests
+]
+
 [tool.interrogate]
 # don't enforce documentation coverage for packaging, testing, the virtual
 # environment, or the CLI (which is documented separately).

--- a/{{cookiecutter.project_slug}}/test/test_init.py
+++ b/{{cookiecutter.project_slug}}/test/test_init.py
@@ -1,13 +1,8 @@
 """Initial testing module."""
 import {{ cookiecutter.module_slug }}
 
-# ruff: noqa: S101 INP001
-# S101 Use of `assert` detected
-# INP001 implicit namespace package
-
 
 def test_version() -> None:
-    """Test whether the package version is valid."""
     version = getattr({{ cookiecutter.module_slug }}, "__version__", None)
     assert version is not None
     assert isinstance(version, str)

--- a/{{cookiecutter.project_slug}}/test/test_init.py
+++ b/{{cookiecutter.project_slug}}/test/test_init.py
@@ -1,6 +1,13 @@
+"""Initial testing module."""
 import {{ cookiecutter.module_slug }}
 
-def test_version():
+# ruff: noqa: S101 INP001
+# S101 Use of `assert` detected
+# INP001 implicit namespace package
+
+
+def test_version() -> None:
+    """Test whether the package version is valid."""
     version = getattr({{ cookiecutter.module_slug }}, "__version__", None)
     assert version is not None
     assert isinstance(version, str)

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/__init__.py
@@ -1,5 +1,3 @@
-"""
-The `{{ cookiecutter.module_slug }}` APIs.
-"""
+"""The `{{ cookiecutter.module_slug }}` APIs."""
 
 __version__ = "{{ cookiecutter.version }}"

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/__main__.py
@@ -1,6 +1,4 @@
-"""
-The `python -m {{ cookiecutter.module_slug }}` entrypoint.
-"""
+"""The `python -m {{ cookiecutter.module_slug }}` entrypoint."""
 
 if __name__ == "__main__":  # pragma: no cover
     from {{ cookiecutter.module_slug }}._cli import main

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/_cli.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/_cli.py
@@ -1,6 +1,8 @@
-"""
-The `{{ cookiecutter.project_slug }}` entrypoint.
-"""
+"""The `{{ cookiecutter.project_slug }}` entrypoint."""
+
+# ruff: noqa: T201
+# T201 `print` found
+
 
 def main() -> None:
     print("Hello, world!")

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/_cli.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.module_slug}}/_cli.py
@@ -1,8 +1,5 @@
 """The `{{ cookiecutter.project_slug }}` entrypoint."""
 
-# ruff: noqa: T201
-# T201 `print` found
-
 
 def main() -> None:
     print("Hello, world!")


### PR DESCRIPTION
Update dependencies to their latest version and constraints.

Fix issues with `make reformat` by ignoring some ruff rules where it makes sense.

Apply the reformatted file changes.