### PR TITLE
pyproject: tweak ruff config

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -60,7 +60,7 @@ $(VENV)/pyvenv.cfg: pyproject.toml
 .PHONY: lint
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		black --check $(ALL_PY_SRCS) && \
+		ruff format --check $(ALL_PY_SRCS) && \
 		ruff $(ALL_PY_SRCS) && \
 		mypy
 
@@ -73,7 +73,7 @@ lint: $(VENV)/pyvenv.cfg
 reformat:
 	. $(VENV_BIN)/activate && \
 		ruff --fix $(ALL_PY_SRCS) && \
-		black $(ALL_PY_SRCS)
+		ruff format $(ALL_PY_SRCS)
 
 .PHONY: test tests
 test tests: $(VENV)/pyvenv.cfg

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -32,7 +32,6 @@ doc = [
 ]
 test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
-    "black ~= 23.0",
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.
     "ruff < 0.0.293",
@@ -59,9 +58,6 @@ Source = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.
 
 [tool.flit.module]
 name = "{{ cookiecutter.__project_import }}"
-
-[tool.black]
-line-length = 100
 
 [tool.coverage.run]
 # don't attempt code coverage for the CLI entrypoints

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -88,8 +88,10 @@ warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 100
-select = ["ALL"]
 target-version = "py38"
+
+[tool.ruff.lint]
+select = ["ALL"]
 
 [tool.ruff.per-file-ignores]
 "{{ cookiecutter.__project_src_path }}/_cli.py" = [


### PR DESCRIPTION
NFC. Newer versions of `ruff` complain about the old config path.