### PR TITLE
Fix generation when documentation is set to none

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,3 +78,19 @@ jobs:
           make package
           make doc
           cd .. && rm -rf /tmp/bit-trails
+
+      - name: run template (no docs)
+        run: |
+          cookiecutter --no-input -o /tmp . documentation='none'
+
+          [[ -d /tmp/python-project/src/python_project ]] || { >&2 echo "not generated?"; exit 1; }
+          [[ ! -f /tmp/python-project/.github/workflows/docs.yml ]] || { >&2 echo "not expecting docs.yml"; exit 1; }
+
+          cd /tmp/python-project
+          make dev
+          make reformat
+          make lint
+          make test
+          make package
+          make doc
+          cd .. && rm -rf /tmp/python-project

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -5,6 +5,8 @@ REMOVE_PATHS = [
     # We delete _cli.py and __main__.py if we're not generating a CLI.
     "{% if cookiecutter.entry_point == '' %} {{ cookiecutter.__project_src_path }}/_cli.py {% endif %}",
     "{% if cookiecutter.entry_point == '' %} {{ cookiecutter.__project_src_path }}/__main__.py {% endif %}",
+    # We delete the docs GH workflow if the project has no documentation
+    "{% if cookiecutter.documentation == 'none' %} .github/workflows/docs.yml {% endif %}",
 ]
 
 for path in REMOVE_PATHS:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -82,9 +82,14 @@ test tests: $(VENV)/pyvenv.cfg
 		python -m coverage report -m $(COV_ARGS)
 
 .PHONY: doc
+{%- if cookiecutter.documentation == 'pdoc' %}
 doc: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		pdoc -o html $(PY_IMPORT)
+{%- elif cookiecutter.documentation == 'none' %}
+doc:
+	@echo "No documentation set up"
+{%- endif %}
 
 .PHONY: package
 package: $(VENV)/pyvenv.cfg


### PR DESCRIPTION
Currently, when running the template with `documentation=none`, the Github workflow to generate the docs using `pdoc` is still present in the project, and the `Makefile` target `doc` still tries to build the documentation using `pdoc`.

This PR changes the template so that when setting `documentation=none`, the GH workflow `docs.yaml` is excluded from the project, and the `make doc` target only prints a message saying that there is no documentation set up.

This PR also adds a testcase to the CI tests, checking that when generating a project with no documentation, the GH workflow `docs.yaml` is missing, and `make doc` exits successfully.