### PR TITLE
dependabot: group GHA updates

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -8,5 +8,9 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    groups:
+      actions:
+        patterns:
+          - "*"
     schedule:
       interval: daily


### PR DESCRIPTION
Another small QoL improvement: GHA bumps tend to be interdependent/noisy, so this takes all of the updates in a single window and groups them into a single PR, rather than one PR per action.