### PR TITLE
Use `ruff check $FILES` instead of `ruff $FILES`

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -61,7 +61,7 @@ $(VENV)/pyvenv.cfg: pyproject.toml
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
 		ruff format --check $(ALL_PY_SRCS) && \
-		ruff $(ALL_PY_SRCS) && \
+		ruff check $(ALL_PY_SRCS) && \
 		mypy
 
 	{%- if cookiecutter.docstring_coverage %}
@@ -72,7 +72,7 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat:
 	. $(VENV_BIN)/activate && \
-		ruff --fix $(ALL_PY_SRCS) && \
+		ruff check --fix $(ALL_PY_SRCS) && \
 		ruff format $(ALL_PY_SRCS)
 
 .PHONY: test tests


### PR DESCRIPTION
Running `make lint` or `make reformat` shows the following warning:
```
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```
The invocation without the `check` subcommand [has been deprecated in version 0.3.0](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#cli-1).

This changes the `Makefile` to fix that.