### PR TITLE
Misc fixes and updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
@@ -26,7 +26,7 @@ jobs:
           make doc
 
       - name: upload docs artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./html/
 
@@ -42,4 +42,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/{{cookiecutter.project_slug}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
       with:
@@ -36,7 +36,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: sign
-      uses: sigstore/gh-action-sigstore-python@v1.2.1
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
         release-signing-artifacts: true

--- a/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
@@ -11,10 +11,10 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
           - "3.12"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           cache: "pip"

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -88,6 +88,10 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = ["ALL"]
+# D203 and D213 are incompatible with D211 and D212 respectively.
+# COM812 and ISC001 can cause conflicts when using ruff as a formatter.
+# See https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules.
+ignore = ["D203", "D213", "COM812", "ISC001"]
 
 [tool.ruff.lint.per-file-ignores]
 {% if cookiecutter.entry_point -%}

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     {%- endif %}
 ]
 dependencies = []
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 doc = [


### PR DESCRIPTION
This PR fixes/updates 3 things:
1. Running `make lint` or `make reformat` would always emit 3 warnings:
    ```sh
    warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
    warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
    warning: The following rules may cause conflicts when used with the formatter: `COM812`, `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
    ```
    The first commit changes `pyproject.toml` so that the conflicting rules are skipped. For the first two warnings, I removed the rules that were already being ignored.

2. Make Python 3.9 the default version, removing 3.8 from the CI test runs and adding 3.12. This follows our guidance in the [Language Standards Coda page](https://coda.io/d/_dGOPJOAZzIF/Language-Standards_su_p2#_lu_uh) (go no lower than 3 releases before the current Python version)

3. Bump the Github Actions versions to the latest ones. This mirrors the PR you would get from dependabot as soon as you create the repo (see https://github.com/trailofbits/pypi-attestation-models/pull/1 for an example)