### PR TITLE
Remove note about interrogate requiring setuptools

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -52,9 +52,6 @@ run: $(VENV)/pyvenv.cfg
 $(VENV)/pyvenv.cfg: pyproject.toml
 	# Create our Python 3 virtual environment
 	python3 -m venv env
-	# NOTE(ekilmer): interrogate v1.5.0 needs setuptools when using Python 3.12+.
-	# This should be fixed when the next release is made
-	$(VENV_BIN)/python -m pip install --upgrade pip setuptools
 	$(VENV_BIN)/python -m pip install -e .[$(INSTALL_EXTRA)]
 
 .PHONY: lint


### PR DESCRIPTION
New releases have been made and this is fixed on Python 3.12