### PR TITLE
Simplify ruff usage and tighten version constraint

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -60,8 +60,8 @@ $(VENV)/pyvenv.cfg: pyproject.toml
 .PHONY: lint
 lint: $(VENV)/pyvenv.cfg
 	. $(VENV_BIN)/activate && \
-		ruff format --check $(ALL_PY_SRCS) && \
-		ruff check $(ALL_PY_SRCS) && \
+		ruff format --check && \
+		ruff check && \
 		mypy
 
 	{%- if cookiecutter.docstring_coverage %}
@@ -72,8 +72,8 @@ lint: $(VENV)/pyvenv.cfg
 .PHONY: reformat
 reformat:
 	. $(VENV_BIN)/activate && \
-		ruff check --fix $(ALL_PY_SRCS) && \
-		ruff format $(ALL_PY_SRCS)
+		ruff check --fix && \
+		ruff format
 
 .PHONY: test tests
 test tests: $(VENV)/pyvenv.cfg

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -34,7 +34,7 @@ test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
 lint = [
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.
-    "ruff ~= 0.2",
+    "ruff ~= 0.4.0",
     "mypy >= 1.0",
     "types-html5lib",
     "types-requests",


### PR DESCRIPTION
After this change, `$(ALL_PY_SRCS)` is only used in the `edit` Makefile target