### PR TITLE
workflows: don't persist credentials on GHA checkout

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
See https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/