### PR TITLE
Fix version generation

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
     - name: sign
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: ./dist/*.tar.gz ./dist/*.whl
         release-signing-artifacts: true

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -33,9 +33,5 @@ jobs:
 
     - name: publish
       uses: pypa/gh-action-pypi-publish@release/v1
-
-    - name: sign
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
-        inputs: ./dist/*.tar.gz ./dist/*.whl
-        release-signing-artifacts: true
+        attestations: true

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -10,9 +10,6 @@ permissions:
   # Used to publish to PyPI with Trusted Publishing.
   id-token: write
 
-  # Used to attach signing artifacts to the published release.
-  contents: write
-
 jobs:
   pypi:
     name: upload release to PyPI

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -20,6 +20,9 @@ classifiers = [
 dependencies = []
 requires-python = ">=3.9"
 
+[tool.setuptools.dynamic]
+version = { attr = "{{ cookiecutter.__project_import }}.__version__" }
+
 [project.optional-dependencies]
 doc = [
     {%- if cookiecutter.documentation == "pdoc" -%}


### PR DESCRIPTION
After https://github.com/trailofbits/cookiecutter-python/pull/28, built packages will always have version `0.0.0`. This PR fixes that, and bumps the `gh-action-sigstore-python` action in `release.yml`