### PR TITLE
Split publish and build GHA jobs

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -29,7 +29,9 @@
         "Proprietary"
     ],
     "_copy_without_render": [
-        ".github/workflows/*.yml"
+        ".github/workflows/docs.yml",
+        ".github/workflows/lint.yml",
+        ".github/workflows/tests.yml"
     ],
     "__prompts__": {
         "project_name": "Human-readable project name (translated into module slug and import)",

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -5,14 +5,9 @@ on:
 
 name: release
 
-permissions:
-  # Used to sign the release's artifacts with sigstore-python.
-  # Used to publish to PyPI with Trusted Publishing.
-  id-token: write
-
 jobs:
-  pypi:
-    name: upload release to PyPI
+  build:
+    name: Build distributions
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -25,10 +20,34 @@ jobs:
         enable-cache: true
         cache-dependency-glob: pyproject.toml
 
-    - name: build
+    - name: Build distributions
       run: uv build
 
-    - name: publish
-      uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Upload distributions
+      uses: actions/upload-artifact@v4
       with:
-        attestations: true
+        name: distributions
+        path: dist/
+
+  publish:
+    name: Publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/{{cookiecutter.project_slug}}
+    needs: [build]
+    permissions:
+      # Used to sign the release's artifacts with sigstore-python.
+      # Used to publish to PyPI with Trusted Publishing.
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: distributions
+          path: dist/
+
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         cache-dependency-glob: pyproject.toml
 
     - name: build
-      run: uvx --from build pyproject-build --installer uv
+      run: uv build
 
     - name: publish
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -91,7 +91,7 @@ doc:
 
 .PHONY: package
 package: $(VENV)/pyvenv.cfg
-	uvx --from build pyproject-build --installer uv
+	uv build
 
 .PHONY: edit
 edit:


### PR DESCRIPTION
- Use `uv build` to build packages
- Split build and publish GHA jobs in order to only grant permissions to the publish job.