### PR TITLE
Add zizmor GHA

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      # required for workflows in private repositories
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run zizmor 🌈
+        # Run it for both this repo and the templated cookiecutter repo.
+        run: uvx zizmor --format sarif . {{cookiecutter.project_slug}}/.github/workflows > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -31,7 +31,8 @@
     "_copy_without_render": [
         ".github/workflows/docs.yml",
         ".github/workflows/lint.yml",
-        ".github/workflows/tests.yml"
+        ".github/workflows/tests.yml",
+        ".github/workflows/zizmor.yml"
     ],
     "__prompts__": {
         "project_name": "Human-readable project name (translated into module slug and import)",

--- a/{{cookiecutter.project_slug}}/.github/workflows/zizmor.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      # required for workflows in private repositories
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
This adds  [zizmor](https://github.com/woodruffw/zizmor) to this repo and to the generated cookie-cutter repository

The workflow that runs on this (the parent) repository audits both this repo's workflows and also the workflows generated by cookiecutter.