### PR TITLE
Update GHA provenance action

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           name: distributions
           path: dist/
       - name: Generate build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v2
         with:
           subject-path: 'dist/*'
 


### PR DESCRIPTION
New major version released: https://github.com/actions/attest-build-provenance/releases/tag/v2.0.0