### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  # Skipping Python dependencies as pyproject.toml contains template variables
+  # that prevent proper parsing
+
+  # Update GitHub Actions of both the template and the repo
+  - package-ecosystem: github-actions
+    directories:
+        - "/"
+    schedule:
+      interval: daily
+
+  - package-ecosystem: github-actions
+    directories:
+        - "{{cookiecutter.project_slug}}/.github/workflows"
+    schedule:
+      interval: daily


### PR DESCRIPTION
This PR adds a dependabot configuration to the repo.

It will automatically update GitHub Actions of both this repo and the template.

Since our `pyproject.toml` contains template variables, we can't parse it with dependabot so our Python dependencies are not updated.

For unknown reasons, merging the two `package-ecosystem` groups fails, and the PR are not opened.