### PR TITLE
ci: update `setup-uv` action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,8 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
         with:
-          enable-cache: true
           cache-dependency-glob: cookiecutter.json
 
       # we need the git config setup here to make sure the subsequent git commit in each test works

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
 
       - name: Run zizmor 🌈
         # Run it for both this repo and the templated cookiecutter repo.

--- a/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/docs.yml
@@ -14,10 +14,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
 
       - name: setup
         run: |

--- a/{{cookiecutter.project_slug}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/lint.yml
@@ -15,10 +15,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
 
       - name: lint
         run: make lint INSTALL_EXTRA=lint

--- a/{{cookiecutter.project_slug}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/release.yml
@@ -15,10 +15,7 @@ jobs:
         persist-credentials: false
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
-        cache-dependency-glob: pyproject.toml
+      uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
 
     - name: Build distributions
       run: uv build

--- a/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
@@ -22,10 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
 
       - name: Install Python ${{ matrix.python }}
         run: uv python install ${{ matrix.python }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/zizmor.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/zizmor.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6
 
       - name: Run zizmor 🌈
         run: uvx zizmor --format sarif . > results.sarif


### PR DESCRIPTION
The new `6.0.0` version of `setup-uv` [includes](https://github.com/astral-sh/setup-uv/releases/tag/v6.0.0#default-cache-dependency-glob) `**/pyproject.toml` in the paths that invalidate the cache, so there's no need to specify it manually anymore.

Furthermore, the cache for GitHub-hosted runners is enabled by default since `v5`, so this commit removes the redundant line to enable it.