### PR TITLE
Enhance cookiecutter template with stricter code quality standards

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -23,6 +23,11 @@
         "none"
     ],
     "docstring_coverage": true,
+    "data_library": [
+        "polars",
+        "pandas",
+        "none"
+    ],
     "license": [
         "Apache 2.0",
         "AGPL v3",
@@ -32,7 +37,8 @@
         ".github/workflows/docs.yml",
         ".github/workflows/lint.yml",
         ".github/workflows/tests.yml",
-        ".github/workflows/zizmor.yml"
+        ".github/workflows/zizmor.yml",
+        "ruff.toml"
     ],
     "__prompts__": {
         "project_name": "Human-readable project name (translated into module slug and import)",

--- a/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/tests.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.9"
-          - "3.10"
           - "3.11"
           - "3.12"
     runs-on: ubuntu-latest

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+# Pre-commit hooks for code quality
+# See https://pre-commit.com for more information
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.2
+    hooks:
+      # Run the formatter
+      - id: ruff-format
+      # Run the linter
+      - id: ruff
+        args: [--fix]
+
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty type check
+        entry: uv run ty check --strict
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true
+
+      {%- if cookiecutter.docstring_coverage %}
+      - id: interrogate
+        name: interrogate docstring coverage
+        entry: uv run interrogate -c pyproject.toml
+        language: system
+        types: [python]
+        pass_filenames: false
+      {%- endif %}
+
+      - id: pytest
+        name: pytest
+        entry: uv run pytest -q
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true
+        # Only run on commit, not on push
+        stages: [commit]
+
+# Configuration
+ci:
+  autofix_prs: true
+  autoupdate_schedule: weekly

--- a/{{cookiecutter.project_slug}}/CLAUDE.md
+++ b/{{cookiecutter.project_slug}}/CLAUDE.md
@@ -1,0 +1,155 @@
+# {{ cookiecutter.project_name }} - Claude Instructions
+
+This document contains project-specific instructions for Claude when working on this codebase.
+
+## Project Overview
+
+{{ cookiecutter.project_description }}
+
+## Code Standards
+
+This project enforces strict code quality standards:
+
+### Code Complexity Limits
+- **Max 50 lines per function** - Split larger functions
+- **Cyclomatic complexity ≤ 8** - Simplify complex logic  
+- **Max 5 positional parameters** - Use keyword arguments or dataclasses
+- **Max 12 branches per function** - Extract to helper functions
+- **Max 6 return statements** - Consolidate exit points
+
+### Style Guidelines
+- **Line length**: 100 characters max
+- **Docstrings**: Google style on all public functions/classes
+- **Type hints**: Required for all function signatures
+- **Tests**: Must live beside code (`test_*.py` or `*_test.py`)
+
+## Quick Commands
+
+```bash
+# Development setup
+make dev
+
+# Run all checks
+make check  # Runs lint + tests
+
+# Code quality
+make lint   # ruff format --check + ruff check + ty check
+make fix    # Auto-fix formatting and lint issues
+make ty     # Run type checker with strict mode
+
+# Testing
+make test   # Run pytest with coverage
+
+# Development
+{% if cookiecutter.entry_point -%}
+make run ARGS="--help"  # Run the CLI
+{%- endif %}
+make doc    # Build documentation
+```
+
+## Project Structure
+
+```
+src/
+└── {{ cookiecutter.__project_import.replace('.', '/') }}/
+    ├── __init__.py
+    {%- if cookiecutter.entry_point %}
+    ├── __main__.py      # CLI entry point
+    ├── _cli.py          # CLI implementation
+    {%- endif %}
+    └── py.typed         # Type checking marker
+
+test/
+└── test_*.py            # Traditional test location
+```
+
+Tests can also live beside source files as `test_*.py` or `*_test.py`.
+
+## Key Libraries
+
+{%- if cookiecutter.data_library == "polars" %}
+- **Data processing**: Polars (preferred over pandas)
+  ```python
+  import polars as pl
+  df = pl.DataFrame({"col": [1, 2, 3]})
+  ```
+{%- elif cookiecutter.data_library == "pandas" %}
+- **Data processing**: Pandas
+  ```python
+  import pandas as pd
+  df = pd.DataFrame({"col": [1, 2, 3]})
+  ```
+{%- endif %}
+
+## Common Patterns
+
+### Error Handling
+```python
+from typing import Result  # If using result types
+
+def process_data(path: str) -> Result[Data, str]:
+    """Process data from file.
+    
+    Args:
+        path: Path to data file.
+        
+    Returns:
+        Result with Data on success, error message on failure.
+    """
+    try:
+        # Implementation
+        return Ok(data)
+    except Exception as e:
+        return Err(f"Failed to process: {e}")
+```
+
+### Logging
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+{%- if cookiecutter.entry_point %}
+
+### CLI Arguments
+Use the existing `_cli.py` structure:
+```python
+parser.add_argument(
+    "--verbose", "-v",
+    action="store_true",
+    help="Enable verbose output"
+)
+```
+{%- endif %}
+
+## Testing Guidelines
+
+- Aim for 100% test coverage (enforced by CI)
+- Use `pytest.mark.parametrize` for multiple test cases
+- Mock external dependencies
+- Test both success and error paths
+
+## CI/CD
+
+GitHub Actions run on every push/PR:
+1. **Linting**: ruff format/check + ty type checking
+2. **Tests**: pytest with coverage
+3. **Security**: zizmor workflow scanning
+{%- if cookiecutter.documentation == "pdoc" %}
+4. **Docs**: Auto-deploy to GitHub Pages
+{%- endif %}
+
+## Important Notes
+
+1. **Never commit code that violates the quality standards** - refactor instead
+2. **All public APIs need Google-style docstrings**
+3. **Type hints are mandatory** - use `ty check --strict`
+4. **Tests can live beside code** - prefer colocated tests for better maintainability
+
+## Project-Specific Instructions
+
+<!-- Add any project-specific Claude instructions here -->
+
+---
+*This file helps Claude understand project conventions. Update it as patterns emerge.*

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -44,6 +44,7 @@ all:
 
 .PHONY: dev
 dev: $(VENV)/pyvenv.cfg
+	uv run pre-commit install
 
 {%- if cookiecutter.entry_point %}
 .PHONY: run
@@ -59,20 +60,30 @@ $(VENV)/pyvenv.cfg: pyproject.toml
 lint: $(VENV)/pyvenv.cfg
 	uv run ruff format --check && \
 		uv run ruff check && \
-		uv run mypy
+		uv run ty check
 
 	{%- if cookiecutter.docstring_coverage %}
 		uv run interrogate -c pyproject.toml .
 	{%- endif %}
 
-.PHONY: reformat
-reformat:
+.PHONY: format
+format: reformat
+
+.PHONY: check
+check: lint test
+
+.PHONY: typecheck ty
+typecheck ty: $(VENV)/pyvenv.cfg
+	uv run ty check --strict
+
+.PHONY: reformat fix
+reformat fix:
 	uv run ruff format && \
 		uv run ruff check --fix
 
 .PHONY: test tests
 test tests: $(VENV)/pyvenv.cfg
-	uv run pytest --cov=$(PY_IMPORT) $(T) $(TEST_ARGS)
+	uv run pytest -q --cov=$(PY_IMPORT) $(T) $(TEST_ARGS)
 	uv run coverage report -m $(COV_ARGS)
 
 .PHONY: doc

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -19,8 +19,14 @@ authors = [
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-dependencies = []
-requires-python = ">=3.9"
+dependencies = [
+    {%- if cookiecutter.data_library == "polars" %}
+    "polars >= 0.20.0",
+    {%- elif cookiecutter.data_library == "pandas" %}
+    "pandas >= 2.0.0",
+    {%- endif %}
+]
+requires-python = ">=3.11"
 
 [tool.setuptools.dynamic]
 version = { attr = "{{ cookiecutter.__project_import }}.__version__" }
@@ -36,7 +42,7 @@ lint = [
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.
     "ruff ~= 0.6.2",
-    "mypy >= 1.0",
+    "ty >= 0.1.0",
     "types-html5lib",
     "types-requests",
     "types-toml",
@@ -44,7 +50,7 @@ lint = [
     "interrogate",
     {%- endif %}
 ]
-dev = ["{{ cookiecutter.project_slug }}[doc,test,lint]", "twine", "build"]
+dev = ["{{ cookiecutter.project_slug }}[doc,test,lint]", "twine", "build", "pre-commit"]
 
 {% if cookiecutter.entry_point -%}
 [project.scripts]
@@ -61,46 +67,12 @@ Source = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.
 # don't attempt code coverage for the CLI entrypoints
 omit = ["{{ cookiecutter.__project_src_path }}/_cli.py"]
 
-[tool.mypy]
-mypy_path = "src"
-packages = "{{ cookiecutter.__project_import }}"
-allow_redefinition = true
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-ignore_missing_imports = true
-no_implicit_optional = true
-show_error_codes = true
-sqlite_cache = true
-strict_equality = true
-warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
+[tool.ty]
+# Astral's experimental type checker
+search_path = ["src"]
+strict = true
 
-[tool.ruff]
-line-length = 100
-include = ["src/**/*.py", "test/**/*.py"]
-
-[tool.ruff.lint]
-select = ["ALL"]
-# D203 and D213 are incompatible with D211 and D212 respectively.
-# COM812 and ISC001 can cause conflicts when using ruff as a formatter.
-# See https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules.
-ignore = ["D203", "D213", "COM812", "ISC001"]
-
-[tool.ruff.lint.per-file-ignores]
-{% if cookiecutter.entry_point -%}
-"{{ cookiecutter.__project_src_path }}/_cli.py" = [
-    "T201", # allow `print` in cli module
-]
-{%- endif %}
-"test/**/*.py" = [
-    "D",    # no docstrings in tests
-    "S101", # asserts are expected in tests
-]
+# Ruff configuration is in ruff.toml
 
 {%- if cookiecutter.docstring_coverage %}
 [tool.interrogate]
@@ -110,3 +82,10 @@ exclude = ["env", "test", "{{ cookiecutter.__project_src_path }}/_cli.py"]
 ignore-semiprivate = true
 fail-under = 100
 {%- endif %}
+
+[tool.pytest.ini_options]
+# Support tests living beside code
+testpaths = ["src", "test"]
+python_files = ["test_*.py", "*_test.py"]
+# Show test durations
+addopts = "-q --durations=10"

--- a/{{cookiecutter.project_slug}}/ruff.toml
+++ b/{{cookiecutter.project_slug}}/ruff.toml
@@ -1,0 +1,45 @@
+# Ruff configuration aligned with CLAUDE.md standards
+line-length = 100
+target-version = "py311"
+
+[lint]
+select = ["ALL"]
+ignore = [
+    "D203",  # Incompatible with D211
+    "D213",  # Incompatible with D212
+    "COM812",  # Can conflict with formatter
+    "ISC001",  # Can conflict with formatter
+]
+
+[lint.mccabe]
+# Maximum cyclomatic complexity
+max-complexity = 8
+
+[lint.pydocstyle]
+# Use Google-style docstrings
+convention = "google"
+
+[lint.pylint]
+# Maximum number of branches for function or method
+max-branches = 12
+# Maximum number of return statements in function or method
+max-returns = 6
+# Maximum number of positional arguments for function or method
+max-positional-args = 5
+
+[lint.per-file-ignores]
+# CLI-specific ignores (will be removed by post-gen hook if not CLI project)
+"src/**/_cli.py" = [
+    "T201",  # Allow print in CLI module
+]
+"test/**/*.py" = [
+    "D",     # No docstrings required in tests
+    "S101",  # Allow assert in tests
+    "PLR2004",  # Allow magic values in tests
+]
+"**/conftest.py" = ["D"]  # No docstrings in pytest config
+
+[format]
+# Consistent with line-length
+line-ending = "lf"
+quote-style = "double"


### PR DESCRIPTION
## Summary
- Updates Python requirement to 3.11+ and removes 3.9/3.10 from CI
- Replaces mypy with Astral's experimental `ty` type checker
- Adds comprehensive code quality configuration aligned with CLAUDE.md standards

## Key Changes

### 1. Stricter Code Quality Constraints
- Added `ruff.toml` with strict limits:
  - Cyclomatic complexity ≤ 8
  - Max 5 positional args, 12 branches, 6 returns per function
  - Google-style docstrings enforced
  - 100-character line length

### 2. Modern Python Tooling
- Replace mypy with `ty` (Astral's experimental type checker)
- Add pre-commit hooks for automated quality checks
- Configure pytest to support tests living beside code

### 3. Enhanced Configuration Options
- New `data_library` option in cookiecutter.json (polars/pandas/none)
- Added CLAUDE.md template for project-specific AI assistant instructions
- Updated Makefile with convenient aliases (`ty`, `fix`, `check`)

### 4. Developer Experience
- Pre-commit hooks automatically run:
  - ruff format/check
  - ty type checking
  - interrogate docstring coverage
  - pytest on commit
- Clear documentation in CLAUDE.md about project standards

## Test Plan
- [ ] Run cookiecutter with various options to ensure template generates correctly
- [ ] Verify pre-commit hooks work as expected
- [ ] Confirm ty type checker runs successfully
- [ ] Test that ruff enforces the configured constraints

🤖 Generated with [Claude Code](https://claude.ai/code)