### PR TITLE
Add default verbosity and timeout

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -44,7 +44,7 @@ format:
 
 .PHONY: test
 test:
-	uv run pytest --cov=$(PY_IMPORT) $(T) $(TEST_ARGS)
+	uv run pytest -svv --timeout=300 --cov=$(PY_IMPORT) $(T) $(TEST_ARGS)
 	uv run coverage report -m $(COV_ARGS)
 
 .PHONY: doc

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -32,7 +32,7 @@ doc = [
     "pdoc"
     {%- endif -%}
 ]
-test = ["pytest", "pytest-cov", "pretend", "coverage[toml]"]
+test = ["pytest", "pytest-cov", "pytest-timeout", "pretend", "coverage[toml]"]
 lint = [
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.


### PR DESCRIPTION
Adds verbose output for easier debugging when a test fails: `-svv`

Adds a default timeout in case a test hangs indefinitely (I experienced this recently on GitHub Actions): [pytest-timeout](https://pypi.org/project/pytest-timeout/)