### PR TITLE
Resolve zizmor lints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,16 @@ updates:
 
   # Update GitHub Actions of both the template and the repo
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directories:
         - "/"
     schedule:
       interval: daily
 
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directories:
         - "{{cookiecutter.project_slug}}/.github/workflows"
     schedule:

--- a/{{cookiecutter.project_slug}}/.github/dependabot.yml
+++ b/{{cookiecutter.project_slug}}/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 
 updates:
   - package-ecosystem: uv
+    cooldown:
+      default-days: 7
     directory: /
     groups:
       python:
@@ -11,6 +13,8 @@ updates:
       interval: daily
 
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     groups:
       actions:


### PR DESCRIPTION
Fix new lint that recommends adding cooldowns to dependabot workflows to mitigate supply chain attacks

https://github.com/trailofbits/cookiecutter-python/security/code-scanning/51
https://github.com/trailofbits/cookiecutter-python/security/code-scanning/52
https://github.com/trailofbits/cookiecutter-python/security/code-scanning/53
https://github.com/trailofbits/cookiecutter-python/security/code-scanning/54

I put 7 days but not sure if that's too long since that's also easily 7 days of not applying security patches
Could be convinced to lower to 3 days or 5 days