### PR TITLE
Replace mypy with pyright. Update Makefile dependencies.

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -29,9 +29,10 @@ run:
 
 .PHONY: lint
 lint:
+	uv sync --group lint
 	uv run ruff format --check && \
 		uv run ruff check && \
-		uv run mypy
+		uv run pyright
 
 	{%- if cookiecutter.docstring_coverage %}
 		uv run interrogate -c pyproject.toml .
@@ -39,11 +40,13 @@ lint:
 
 .PHONY: format
 format:
+	uv sync --group lint
 	uv run ruff format && \
 		uv run ruff check --fix
 
 .PHONY: test
 test:
+	uv sync --group test
 	uv run pytest -svv --timeout=300 --cov=$(PY_IMPORT) $(T) $(TEST_ARGS)
 	uv run coverage report -m $(COV_ARGS)
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -37,7 +37,7 @@ lint = [
     # NOTE: ruff is under active development, so we pin conservatively here
     # and let Dependabot periodically perform this update.
     "ruff ~= 0.12",
-    "mypy >= 1.0",
+    "pyright ~= 1.1.407",
     "types-html5lib",
     "types-requests",
     "types-toml",
@@ -66,24 +66,13 @@ Source = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.
 # don't attempt code coverage for the CLI entrypoints
 omit = ["{{ cookiecutter.__project_src_path }}/_cli.py"]
 
-[tool.mypy]
-mypy_path = "src"
-packages = "{{ cookiecutter.__project_import }}"
-allow_redefinition = true
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-ignore_missing_imports = true
-no_implicit_optional = true
-show_error_codes = true
-sqlite_cache = true
-strict_equality = true
-warn_no_return = true
-warn_redundant_casts = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_configs = true
-warn_unused_ignores = true
+[tool.pyright]
+include = ["src", "test"]
+exclude = []
+reportUnusedImport = "warning"
+reportUnusedVariable = "warning"
+reportGeneralTypeIssues = "error"
+typeCheckingMode = "strict"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
@dhalf found that pyright might be a better solution going forward.

> I had a more careful look at the differences between the two type checkers
> It turns out pyright is better integrated because it is compatible with LSP. That's why we get those nice inline diagnostics and code suggestions. It also appears to be faster and more modern and more in line with new Python typing specifications (https://htmlpreview.github.io/?https://github.com/python/typing/blob/main/conformance/results/results.html).
> So if we can, I think using uv + ruff + pyright is the best combination

What do you all think?