### PR TITLE
Group dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
     cooldown:
       default-days: 7
     directories:
-        - "/"
-        - "{{cookiecutter.project_slug}}/.github/workflows"
+      - "/"
+      - "{{cookiecutter.project_slug}}/.github/workflows"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Makes the dependabot updates way easier to review and less wasteful

@DarkaMaul i saw that you had split up the github action updates due to a bug? Curious how you tested it. (https://github.com/trailofbits/cookiecutter-python/pull/42)

I'm hoping they fixed it after a year since it's quite annoying to have to go through like 2n dependabot updates every time there's an update