### PR TITLE
Change Dependabot schedule from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,4 @@ updates:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
## Summary
- Switches the Dependabot GitHub Actions update schedule from `daily` to `weekly`
- Daily frequency creates unnecessary PR churn for action updates; weekly is sufficient to stay current

## Test plan
- [ ] Verify Dependabot picks up the new schedule on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)