### PR TITLE
Fix namespace library generation and audit target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,28 @@ jobs:
           make doc
           cd .. && rm -rf /tmp/tob-r-and-e-python-project
 
+      - name: run template (namespace, library)
+        run: |
+          uvx cookiecutter --no-input -o /tmp . project_namespace_import=tob.r_and_e repo_type=library
+
+          [[ -d /tmp/tob-r-and-e-python-project/src/tob/r_and_e/python_project ]] || { >&2 echo "not generated?"; exit 1; }
+          [[ ! -f /tmp/tob-r-and-e-python-project/src/tob/r_and_e/python_project/_cli.py ]] || { >&2 echo "not expecting CLI module"; exit 1; }
+          [[ ! -f /tmp/tob-r-and-e-python-project/src/tob/r_and_e/python_project/__main__.py ]] || { >&2 echo "not expecting main module"; exit 1; }
+
+          cd /tmp/tob-r-and-e-python-project
+          git init . && git add . && git commit -m "Initial commit"
+          make format
+
+          git diff --exit-code || { >&2 echo "please format"; exit 1; }
+
+          uv run prek run --all-files
+          make lint
+          make test
+          make audit
+          make build
+          make doc
+          cd .. && rm -rf /tmp/tob-r-and-e-python-project
+
       - name: run template (namespace, short slug)
         run: |
           uvx cookiecutter --no-input -o /tmp . project_namespace_import=tob.r_and_e "project_name=Bit Trails" project_slug=bit-trails

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,5 +1,14 @@
 import os
 
+# Potentially new directory for namespace project
+namespace_project_dir = os.path.join(
+    os.getcwd(), "{{ cookiecutter.__project_src_path }}"
+)
+if not os.path.exists(namespace_project_dir):
+    module_dir = os.path.join(os.getcwd(), "src", "{{ cookiecutter.__module_import }}")
+    os.makedirs(os.path.dirname(namespace_project_dir), exist_ok=True)
+    os.rename(module_dir, namespace_project_dir)
+
 REMOVE_PATHS = [
     # We delete _cli.py and __main__.py if we're not generating a CLI.
     "{% if cookiecutter.entry_point == '' %} {{ cookiecutter.__project_src_path }}/_cli.py {% endif %}",
@@ -15,12 +24,3 @@ for path in REMOVE_PATHS:
             os.rmdir(path)
         else:
             os.unlink(path)
-
-# Potentially new directory for namespace project
-namespace_project_dir = os.path.join(
-    os.getcwd(), "{{ cookiecutter.__project_src_path }}"
-)
-if not os.path.exists(namespace_project_dir):
-    module_dir = os.path.join(os.getcwd(), "src", "{{ cookiecutter.__module_import }}")
-    os.makedirs(namespace_project_dir)
-    os.rename(module_dir, os.path.join(namespace_project_dir))

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -54,8 +54,7 @@ test:
 
 .PHONY: audit
 audit:
-	uv sync --group audit
-	uv run pip-audit .
+	uv audit
 
 .PHONY: doc
 {%- if cookiecutter.documentation == 'pdoc' %}

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,5 +1,3 @@
-SHELL := /bin/bash
-
 PY_IMPORT = {{ cookiecutter.__project_import }}
 
 # Optionally overridden by the user in the `test` target.

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -41,12 +41,10 @@ lint = [
     "interrogate",
     {%- endif %}
 ]
-audit = ["pip-audit"]
 dev = [
     {include-group = "doc"},
     {include-group = "test"},
     {include-group = "lint"},
-    {include-group = "audit"},
     "prek",
 ]
 


### PR DESCRIPTION
## Summary

- replace the generated `pip-audit` dependency group with `uv audit`
- stop forcing `/bin/bash` in generated Makefiles so recipes use Make's default POSIX shell instead of a distro-specific Bash path
- relocate namespace packages before CLI cleanup so namespace library projects remove `_cli.py` and `__main__.py` correctly
- add CI coverage for namespace library generation

## Validation

- `git diff --check main..HEAD`
- generated a default project and verified `src/python_project` plus CLI modules
- generated `project_namespace_import=tob.r_and_e repo_type=library` and verified the namespace package exists without CLI modules
- ran generated `make audit` on NixOS without a `SHELL=` override